### PR TITLE
Modified Dockerfile to use supervisord and nginx as reverse proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,14 @@
 # bitcoin-testnet-box docker image
 
-FROM ubuntu
+FROM ubuntu:22.04
 LABEL maintainer="Sean Lavine <lavis88@gmail.com>"
 
 # install make
 RUN apt-get update && \
-	apt-get install --yes make wget
+	apt-get install --yes make wget nginx supervisor
 
-# create a non-root user
-RUN adduser --disabled-login --gecos "" tester
-
-# run following commands from user's home directory
-WORKDIR /home/tester
+# use btc as folder
+WORKDIR /btc
 
 ENV BITCOIN_CORE_VERSION "0.21.0"
 
@@ -27,21 +24,18 @@ RUN mkdir tmp \
 RUN rm -r tmp
 
 # copy the testnet-box files into the image
-ADD . /home/tester/bitcoin-testnet-box
-
-# make tester user own the bitcoin-testnet-box
-RUN chown -R tester:tester /home/tester/bitcoin-testnet-box
+ADD . /btc/bitcoin-testnet-box
 
 # color PS1
-RUN mv /home/tester/bitcoin-testnet-box/.bashrc /home/tester/ && \
-	cat /home/tester/.bashrc >> /etc/bash.bashrc
-
-# use the tester user when running the image
-USER tester
+RUN mv /btc/bitcoin-testnet-box/.bashrc /btc/ && \
+	cat /btc/.bashrc >> /etc/bash.bashrc
 
 # run commands from inside the testnet-box directory
-WORKDIR /home/tester/bitcoin-testnet-box
+WORKDIR /btc/bitcoin-testnet-box
+
+# copy nginx
+COPY nginx.conf /etc/nginx/sites-enabled/default
 
 # expose two rpc ports for the nodes to allow outside container access
-EXPOSE 19001 19011
-CMD ["/bin/bash"]
+EXPOSE 19001 19011 8080
+CMD supervisord -c supervisord.conf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  btcnode:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: btc
+    ports:
+      - '8085:8080'
+      - '8086:8081'

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,18 @@
+server {
+            listen 8080;
+            location / {
+                proxy_set_header   X-Real-IP        $remote_addr;
+                proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+                proxy_set_header   Host             $host;
+                proxy_pass http://127.0.0.1:19001;
+            }
+    }
+server {
+        listen 8081;
+        location / {
+            proxy_set_header   X-Real-IP        $remote_addr;
+            proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+            proxy_set_header   Host             $host;
+            proxy_pass http://127.0.0.1:19011;
+        }
+}

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,18 @@
+[supervisord]
+nodaemon=true
+
+[program:nginx]
+command=nginx -g "daemon off;"
+autostart=true
+autorestart=true
+startretries=5
+numprocs=1
+startsecs=0
+
+[program:btc]
+command=make start
+autostart=true
+autorestart=false
+startretries=5
+numprocs=1
+startsecs=0


### PR DESCRIPTION
Added nginx.conf so that we can connect from outside to the node as it was not allowing any connection even if uncommenting the jsonrpc directive
supervisord.conf contains the necessary configuration to allow the image to run smoothly.
docker-compose.yml -> it'll use port 8085 and 8086 to communicate with the node. This can be changed by the developer. Remember: HOST:CONTAINER.